### PR TITLE
fix(response): clean up chunk text

### DIFF
--- a/inception/embedding_service.py
+++ b/inception/embedding_service.py
@@ -163,8 +163,13 @@ class EmbeddingService:
             ),
         )
 
+        # Clean up the chunks
+        clean_chunks = [
+            chunk.replace("search_document: ", "") for chunk in all_chunks
+        ]
+
         # Create pairs of embeddings and corresponding chunks
-        embedding_chunk_pairs = zip(embeddings, all_chunks)
+        embedding_chunk_pairs = zip(embeddings, clean_chunks)
         # Split the pairs into groups based on the number of chunks per text
         sliced_results = [
             list(islice(embedding_chunk_pairs, 0, i)) for i in chunk_counts


### PR DESCRIPTION
clean up chunk text in the response to remove prefix for easier downstream processing

Per discussion: https://github.com/freelawproject/courtlistener/pull/5298#discussion_r2010904744
We should clean up the chunk text in the response to remove the prefix for easier downstream processing and keeping the opinion text clean