### PR TITLE
4676 docker gpu fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ ENV PYTHONUNBUFFERED=1 \
 
 
 # The installer requires curl (and certificates) to download the latest uv release
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get install -y --no-install-recommends && apt-get install build-essential -y \
     curl ca-certificates git \
     && rm -rf /var/lib/apt/lists/*
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ It is a high-performance FastAPI service that generates text embeddings using Se
 
 The service is optimized to handle two main use cases:
 - Embedding search queries: Quick, CPU-based processing for short search queries
-- Embedding court opinions: GPU-accelerated processing for longer legal documents, with intelligent text chunking to maintain context
+- Embedding court opinions: NVIDIA CUDA GPU-accelerated processing for longer legal documents, with intelligent text chunking to maintain context
 
 ## Features
 
@@ -180,19 +180,52 @@ Build:
 docker build -t inception:latest --build-arg TARGET_ENV=prod .
 ```
 
-Run:
+Run with CPU:
 ```bash
 docker run -d -p 8005:8005 inception
 ```
 
+Run with GPU:
+```bash
+docker run -d \
+  --rm \
+  --runtime=nvidia \
+  -e NVIDIA_VISIBLE_DEVICES=all \
+  -e NVIDIA_DRIVER_CAPABILITIES=compute \
+  --shm-size=16g \
+  -p 8005:8005 \
+  inception
+```
+
 Run from hosted image:
+
+with CPU:
 ```bash
 docker run -d -p 8005:8005 freelawproject/inception:v2
 ```
 
-For development run it with docker compose:
+with GPU:
+```bash
+docker run -d \
+  --rm \
+  --runtime=nvidia \
+  -e NVIDIA_VISIBLE_DEVICES=all \
+  -e NVIDIA_DRIVER_CAPABILITIES=compute \
+  --shm-size=16g \
+  -p 8005:8005 \
+  freelawproject/inception:v2
+```
+
+For development, run it with docker compose:
+
+with CPU:
 ```bash
 docker compose -f docker-compose.dev.yml up
+```
+
+with GPU:
+```bash
+docker compose -f docker-compose.dev-gpu.yml up
 ```
 
 To handle more concurrent tasks, increase the number of workers:
@@ -203,8 +236,8 @@ docker run -d -p 8005:8005 -e EMBEDDING_WORKERS=4 freelawproject/inception:v2
 Check that the service is running:
 ```bash
 curl http://localhost:8005
-# Should return: "Heartbeat detected."
 ```
+Should return: "Heartbeat detected."
 
 ### Running the Service Outside of Docker
 
@@ -223,13 +256,15 @@ uvicorn inception.main:app \
 ```
 
 ## Running tests
+
+Run all the tests:
 ```bash
-# Run all the tests
 docker exec -it inception-embedding-service pytest tests -v
 ```
+
+Run tests from a marker:
 ```bash
-  # Run tests from a marker
-  docker exec -it inception-embedding-service pytest -m embedding_generation -v
+docker exec -it inception-embedding-service pytest -m embedding_generation -v
 ```
 See all available markers in [pytest.ini](pytest.ini)
 
@@ -329,13 +364,27 @@ docker exec -it inception-embedding-service mypy inception
 1. The best way is to update the dependencies in Docker
 
 Step 1: Build the docker image
+
+with CPU:
 ```bash
 docker compose -f docker-compose.dev.yml build --no-cache
 ```
 
+with GPU:
+```bash
+docker compose -f docker-compose.dev-gpu.yml build --no-cache
+```
+
 Step 2: Spin-up the docker image
+
+with CPU:
 ```bash
 docker compose -f docker-compose.dev.yml up
+```
+
+with GPU:
+```bash
+docker compose -f docker-compose.dev-gpu.yml up
 ```
 
 Step 3: Add the new dependencies

--- a/docker-compose.dev-gpu.yml
+++ b/docker-compose.dev-gpu.yml
@@ -1,0 +1,27 @@
+version: "3.8"
+
+services:
+  inception-embedding-service:
+    container_name: inception-embedding-service
+    privileged: true
+    environment:
+      - NVIDIA_DRIVER_CAPABILITIES=all
+    runtime: nvidia
+    build:
+      context: .
+      args:
+        TARGET_ENV: prod
+    ports:
+      - "8005:8005"
+    volumes:
+      - .:/app
+    env_file:
+      - .env
+    shm_size: '16gb'
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu,compute]

--- a/inception/main.py
+++ b/inception/main.py
@@ -23,6 +23,8 @@ try:
 except (LookupError, zipfile.BadZipFile):
     nltk.download("punkt", quiet=True)
     nltk.download("punkt_tab", quiet=True)
+except FileExistsError:
+   nltk.data.find("tokenizers/punkt_tab")
 
 
 # Initialize Sentry

--- a/inception/main.py
+++ b/inception/main.py
@@ -24,7 +24,7 @@ except (LookupError, zipfile.BadZipFile):
     nltk.download("punkt", quiet=True)
     nltk.download("punkt_tab", quiet=True)
 except FileExistsError:
-   nltk.data.find("tokenizers/punkt_tab")
+    nltk.data.find("tokenizers/punkt_tab")
 
 
 # Initialize Sentry


### PR DESCRIPTION
When starting the embedding process https://github.com/freelawproject/courtlistener/issues/4676, we noticed the GPU is not being properly utilized. This PR is to address the GPU utilization issue.

The PR includes:
- address the inconsistency between `start_multi_process_pool` and `encode`:
   - if we use `start_multi_process_pool`, we need to use `encode_multi_process`. This is optimized for when we have multiple GPUs. This can also be used on CPUs when GPUs are not found, which defaults to 4 CPUs, however, the integration with fastapi and multi_process_pool is tricky. Since we only have one GPU, we do not need to use `start_multi_process_pool`. When we run it on CPU, we can assign multiple gunicorn workers instead of using `start_multi_process_pool`, so we also do not need to use `start_multi_process_pool`.
   - if we use `compile`, then we should use `encode`. This does not use multi_process but given the reasons above, this is a better approach for now. We can revisit later if we decide to use multiple GPUs where `start_multi_process_pool` becomes relevant.
- added yml file for docker compose with gpu for monitoring the development in gpu environment
- added missing installer in dockerfile
- added torch setting for faster matrix multiplication with the gpu model
- added a logic to catch nltk download error when using multiple workers
- fixed documentation for GPU utilization

Furthermore, to ensure GPU is utilized and accessible within the docker container, we need to:
- Install the NVIDIA driver (for AWS: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/install-nvidia-driver.html)
- Install the NVIDIA container toolkit (for docker / k8s: https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html#configuring-docker)
- Run docker with the proper params (see updated README). This is important to ensure docker can access the GPU.
- Monitor the log
   - below is an example of proper GPU utilization in embedding generation, note all red boxes indicate proper cuda usage
   - <img width="1373" alt="Screenshot 2025-04-16 at 12 01 46 PM" src="https://github.com/user-attachments/assets/9124c89f-b15e-4160-9cf3-3c3ee08f9e83" />
   - below is an example of embedding generation on CPU, note all red boxes indicate the model is initiated and running on cpu device
   - <img width="1367" alt="Screenshot 2025-04-16 at 11 07 52 AM" src="https://github.com/user-attachments/assets/4fb88069-ed4b-45df-a00f-5a1c244ed1c1" />
  - note that an important clue as to whether the model is properly running on GPU is the absence of the 'torch.compile' error
- Monitor GPU usage
   - `nvidia-smi` can be used to monitor the GPU usage, this command is available once the NVIDIA driver is installed.
   - Before the embedding service is initialized, we can confirm there are no processes running on cuda
   
   - <img width="650" alt="Screenshot 2025-04-16 at 11 54 21 AM" src="https://github.com/user-attachments/assets/4f712957-e557-4180-b60c-20066d570358" />

   - After the embedding service is initialized, we can monitor the GPU usage, we can see that the memory usage changes as we send in requests
   
   - <img width="649" alt="Screenshot 2025-04-16 at 12 05 14 PM" src="https://github.com/user-attachments/assets/8fc00e1e-1f5c-4f53-ac72-f6471fdde384" />

- We should ensure to use one worker when using GPU (change `EMBEDDING_WORKERS` to 1 in `.env`) as we only have 1 GPU to utilize
- Note that the first time a request is sent, the model needs to be compiled which takes some time, we can probe it with a smaller batch first to compile the model and keep the GPU up before sending in large batches
- I suggest we start with one request of 50K tokens. In my tests run on g5.2xlarge (a smaller GPU than the one used in production), embedding 50K tokens took on average 4 seconds, varying depending on whether the GPU is still wrapping up a previous request. The production GPU should be faster. We should monitor the process to ensure it finishes within a few seconds before trying to send multiple requests of large batches.
