### PR TITLE
perf(chunking): threadpool

### DIFF
--- a/tests/test_embedding_service.py
+++ b/tests/test_embedding_service.py
@@ -213,7 +213,7 @@ class TestInputValidation:
                 "name": "empty batch",
                 "input": {"documents": []},
                 "expected_status": HTTPStatus.UNPROCESSABLE_ENTITY,
-                "expected_error": "empty text list",
+                "expected_error": "empty text dict",
             },
             {
                 "name": "invalid document",


### PR DESCRIPTION
Replace chunking for loop with threadpool to enable parallel processing of chunking, hopefully this will speed up the chunking processes a bit. Had to change the tracking and the returned object to keep track of document id as items are processed in random orders in threadpool.

We tried with processpool but it didn't provide any acceleration, likely due to the overhead in pickling and unpickling the data, and it requires breaking the chunking logic out of the class into its own function and pass class variables around, not ideal. So going with threadpool to see if it makes any difference.